### PR TITLE
Fix typo in dev README

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -2,7 +2,7 @@
 
     sh up.sh
 
-Once inside the the container, you have to manually build and run the app:
+Once inside the container, you have to manually build and run the app:
 
     cd /var/app/frontend && npm install && npm run build
     cd /var/app/backend && npm install


### PR DESCRIPTION
## Summary
- fix typo in dev instructions

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_b_68501c8eba30832ba3701a1215e5fd92