### PR TITLE
Update README with new default port

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
     ```
     * Use `-d` to run in detached mode (in the background).
 4.  **Access the Web UI:**
-    * Navigate to `http://localhost:8080` (or the port configured in `docker-compose.yml`) in your browser.
+    * Navigate to `http://localhost:14333` in your browser. This is the default port and can be overridden via the `WEBUI_PORT` environment variable or in `docker-compose.yml`.
 
 ---
 
@@ -122,7 +122,7 @@ SkyRoute-Enterprise is released under the MIT License. See the `LICENSE` file fo
 A: SkyRoute-Enterprise is an automation platform built around a Docker image combining the Cloudflare CLI (`cloudflared`) with a Web UI, designed to simplify Cloudflare tunnel management and deployment, often integrated with Cloudflare Workers.
 
 **Q: Where can I access the Web UI?**
-A: After running the application using `docker-compose up`, you can typically access it locally at `http://localhost:8080`, unless the port is configured differently.
+A: After running the application using `docker-compose up`, you can typically access it locally at `http://localhost:14333`. The port can be overridden with the `WEBUI_PORT` environment variable or in `docker-compose.yml`.
 
 **Q: How is the Cloudflare Worker related?**
 A: The Cloudflare Worker (code provided in previous examples) often acts as the public-facing API endpoint or proxy, interacting with the Cloudflare API and potentially routing requests to services exposed via tunnels managed by SkyRoute-Enterprise components.


### PR DESCRIPTION
## Summary
- fix docs for accessing the web UI

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68501c9f0d84832ba25c899362e9951b