### PR TITLE
Replace token with GitHub secret

### DIFF
--- a/.github/workflows/daily-redeploy.yml
+++ b/.github/workflows/daily-redeploy.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Redeploy to Cloudflare Worker
         env:
-          CF_API_TOKEN: 6y1UyXmJN98BFSvnzmxGKkp-7UsC8kJcCc9lXhwo
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
         run: wrangler deploy
 
       - name: Notify Success

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@
 4.  **Access the Web UI:**
     * Navigate to `http://localhost:14333` in your browser. This is the default port and can be overridden via the `WEBUI_PORT` environment variable or in `docker-compose.yml`.
 
+### Configure GitHub Actions Secret
+
+To enable automated deployments, add your Cloudflare API token as a secret:
+
+1.  In your GitHub repository, open **Settings** ➔ **Secrets and variables** ➔ **Actions**.
+2.  Click **New repository secret** and create `CF_API_TOKEN` with your token.
+
 ---
 
 ## Upcoming Improvements (TODO)


### PR DESCRIPTION
## Summary
- use the `CF_API_TOKEN` secret for the daily redeploy workflow
- document how to set `CF_API_TOKEN` in the repo settings

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_68558cf6f4f0832b84938886c40956bf