### PR TITLE
Fix workflow test path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,6 @@ jobs:
         run: npm install
 
       - name: Run backend tests
-        working-directory: app/backend
         run: npm test
 
       - name: Publish to Cloudflare Worker


### PR DESCRIPTION
## Summary
- fix workflow: run tests at repo root instead of app/backend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6855a26a6f98832badeaf6e0c980de4f