### PR TITLE
Add cloudflared deployment workflow

### DIFF
--- a/.github/workflows/deploy-cloudflared.yml
+++ b/.github/workflows/deploy-cloudflared.yml
@@ -1,0 +1,38 @@
+name: Deploy Cloudflared Config
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'cloudflared/config.yml'
+
+jobs:
+  deploy:
+    name: Deploy to Local Server
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: SSH to server and deploy
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            mkdir -p ~/cloudflared
+            cat <<'CONFIG' > ~/cloudflared/config.yml
+${{ toJSON(fromJSON(file('cloudflared/config.yml'))) }}
+CONFIG
+            if [ "$(docker ps -q -f name=cloudflared-tunnel)" ]; then
+                echo "Stopping and removing existing cloudflared container..."
+                docker stop cloudflared-tunnel
+                docker rm cloudflared-tunnel
+            fi
+            echo "Starting new cloudflared container..."
+            docker run -d --name cloudflared-tunnel --restart unless-stopped \
+              --network host \
+              cloudflare/cloudflared:latest tunnel --no-autoupdate run --token ${{ secrets.CF_TUNNEL_TOKEN }}
+

--- a/cloudflared/config.yml
+++ b/cloudflared/config.yml
@@ -1,0 +1,10 @@
+# Cloudflared tunnel configuration for local services
+
+# The hostname values must be CNAME records in Cloudflare DNS pointing to the tunnel ID
+ingress:
+  - hostname: ha.yourdomain.com
+    service: http://localhost:8123
+  - hostname: files.yourdomain.com
+    service: http://192.168.1.55:8080
+  # Default rule
+  - service: http_status:404


### PR DESCRIPTION
## Summary
- add a sample cloudflared config for tunnel routing
- add GitHub Actions workflow to deploy cloudflared config via SSH

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685d94e113ec832b9257dca978cb388e